### PR TITLE
[forms][create] #49 - Support boolean / string array types.

### DIFF
--- a/forms/index.js
+++ b/forms/index.js
@@ -32,6 +32,7 @@ forms.method("generate", generate, {
 });
 
 function generate (options, callback) {
+  this.data = fixDataTypes(options);
   resource.view.create({ path: __dirname + '/view', input: "html"}, function (err, view) {
     var str = '', form;
     form = view.form[options.method] || view.form['method'];
@@ -43,5 +44,32 @@ function generate (options, callback) {
     });
   });
 };
+
+// form variables are posted as strings, so we use the 
+// resource schema to reset the values to the proper types
+function fixDataTypes(options) {
+  var data = options.data;
+  var r = resource.resources[options.resource];
+  if(Object.keys(data).length === 0)
+    return data; //{}
+  Object.keys(r.schema.properties).forEach(function (prop, i) {
+    if(data.hasOwnProperty(prop)) {
+      var item = r.schema.properties[prop];
+      switch(item['type']) {
+        case "boolean":
+          data[prop] = data[prop] === 'true' ? true : false;
+          break;
+        case "array":
+          // TODO: refactor required for different array types
+          data[prop] = data[prop].replace(', ', '').split(',');
+          break;
+        case "number":
+          data[prop] = Number(data[prop]);
+          break;
+      }
+    }
+  });
+  return data;
+}
 
 exports.forms = forms;

--- a/forms/index.js
+++ b/forms/index.js
@@ -56,14 +56,14 @@ function fixDataTypes(options) {
     if(data.hasOwnProperty(prop)) {
       var item = r.schema.properties[prop];
       switch(item['type']) {
-        case "boolean":
+        case 'boolean':
           data[prop] = data[prop] === 'true' ? true : false;
           break;
-        case "array":
+        case 'array':
           // TODO: refactor required for different array types
           data[prop] = data[prop].replace(', ', '').split(',');
           break;
-        case "number":
+        case 'number':
           data[prop] = Number(data[prop]);
           break;
       }

--- a/forms/index.js
+++ b/forms/index.js
@@ -32,7 +32,7 @@ forms.method("generate", generate, {
 });
 
 function generate (options, callback) {
-  this.data = fixDataTypes(options);
+  options.data = fixDataTypes(options);
   resource.view.create({ path: __dirname + '/view', input: "html"}, function (err, view) {
     var str = '', form;
     form = view.form[options.method] || view.form['method'];

--- a/forms/view/form/create.js
+++ b/forms/view/form/create.js
@@ -4,6 +4,22 @@ module['exports'] = function (options, callback) {
 
  options = options || {};
  var r = resource.resources[options.resource];
+
+ // convert form posted string values into their proper schema types
+ Object.keys(r.schema.properties).forEach(function (prop, i) {
+   if(options.data.hasOwnProperty(prop)) {
+     switch(r.schema.properties[prop].type) {
+       case "boolean":
+         options.data[prop] = options.data[prop] === 'true' ? true : false;
+         break;
+       case "array":
+         // TODO: account for the non-string array (items) types
+         options.data[prop] = options.data[prop].replace(', ', '').split(',');
+         break;
+     }
+   }
+ });
+
  var $ = this.$,
      self = this,
      output = '',

--- a/forms/view/form/create.js
+++ b/forms/view/form/create.js
@@ -4,22 +4,7 @@ module['exports'] = function (options, callback) {
 
  options = options || {};
  var r = resource.resources[options.resource];
-
- // convert form posted string values into their proper schema types
- Object.keys(r.schema.properties).forEach(function (prop, i) {
-   if(options.data.hasOwnProperty(prop)) {
-     switch(r.schema.properties[prop].type) {
-       case "boolean":
-         options.data[prop] = options.data[prop] === 'true' ? true : false;
-         break;
-       case "array":
-         // TODO: account for the non-string array (items) types
-         options.data[prop] = options.data[prop].replace(', ', '').split(',');
-         break;
-     }
-   }
- });
-
+ 
  var $ = this.$,
      self = this,
      output = '',

--- a/forms/view/form/inputs/boolean.html
+++ b/forms/view/form/inputs/boolean.html
@@ -1,6 +1,8 @@
 <div class="control-group">
   <label class="control-label" for="input-name">checkbox name</label>
   <div class='controls'>
-    <input type="checkbox" id="input-id" name="input-name" value="true" />
+  	<input type="hidden" value="" name="input-name" />
+    <input type="checkbox" id="input-id" value="" />
+    <span class="help-inline"></span>
   </div>
 </div>

--- a/forms/view/form/inputs/boolean.js
+++ b/forms/view/form/inputs/boolean.js
@@ -1,36 +1,38 @@
 //
-// string.js - input fields for String types
+// boolean.js - input fields for boolean types
 //
 
-module['exports'] = function (input, options, callback) {
+module['exports'] = function (options, callback) {
   //
   // Todo: This load statement should be moved to Viewful
   //
+  var input = options.control;
   var $ = this.$.load(this.template);
-  if(options.error) {
-    options.error.validate.errors.forEach(function(error){
-      if(input.name === error.property){
-        $('.control-group').addClass('error');
-        $('.help-inline').html(error.message);
-      }
-    });
-    for(var v in options.error.value) {
-      if(input.name === v){
-        input.value = options.error.value[v];
-      }
-    }
+  if(typeof input.error !== 'undefined') {
+    $('.control-group').addClass('error');
+    $('.help-inline').html(input.error.message);
   }
+  var label = $('.control-label');
+  label.attr('for', input.name);
+  label.html(input.name);
 
-  $('.control-label').attr('for', input.name);
-  $('.control-label').html(input.name);
-  $('input').attr('id',  input.name);
-  $('input').attr('name', input.name);
+  var hidden = $('input[type=hidden]');
+  hidden.attr('id', input.name);
+  hidden.attr('name', input.name);
 
-  if(input.value.toString() ===  "true") {
-    $('input').attr('checked', 'CHECKED');
+  var checkbox = $('input[type=checkbox]');
+  checkbox.attr('onclick', 
+      'document.getElementById("' + input.name + '").value = this.checked');
+
+  $('input').attr('value', input.value.toString());
+
+  if(input.value.toString() === "true") {
+    checkbox.attr('checked', 'CHECKED');
     //selected = ' SELECTED="SELECTED"'; // Bad string concat man!
   }
+  else {
+    checkbox.removeAttr('checked');
+  }
 
-
-  return $.html();
+  return callback(null, $.html());
 };


### PR DESCRIPTION
When creating new objects of type boolean / string array, the form values are posted as string values. The validator subsequently marks the options.data as an invalid schema.

I also fixed the boolean.js / html view to support true/false checked state - as per normal html posting of form data, if the checkbox is unchecked, the form field is not posted to the server. I added a little bit of js to populate a hidden field so the boolean state could be retained.
